### PR TITLE
Config example for Honeycomb Bravo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,82 @@ install_janus.sh
 old-testing
 MAKEPACKAGES.txt
 SIM-*.tar.gz
+frankenrouter.cache.json
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide

--- a/config_examples/frankenusb-frankensim-honeycomb-bravo.conf
+++ b/config_examples/frankenusb-frankensim-honeycomb-bravo.conf
@@ -1,0 +1,428 @@
+# -*- mode: Python;-*-
+# pylint: disable=invalid-name,missing-module-docstring
+
+# Example configuration file for TCA Boeing Yoke and Honeycomb Bravo Throttle Quadrant
+
+# Throttle sync sound, played if you move the throttles near the
+# PSX position while autothrottle is engaged. Usage: move throttles
+# until you hear the sound, then press A/T disconnect three times and
+# you have manual control without a big jump in PSX throttle position
+
+CONFIG_MISC = {
+    'THROTTLE_SYNC_SOUND': "d:/fs/psx/Audio/Basics/cab1.wav"
+}
+
+CONFIG = {
+    #
+    # Bravo Throttle Quadrant descriptions
+    #
+    # Left rotary switch: Autobrake RTO-none-1-2-3
+    # HDG: pushback toggle
+    # NAV: pushback direction
+    # Rotary encoder dec/inc: pushback heading
+    # Autopilot: CMD A
+    #
+    # Axises are numbered, left to right: 0, 5, 4, 3
+    # Reversers are working (individually)
+    # Flap lever is working
+    # Speedbrake is working, armed = armed
+    #
+    'Bravo Throttle Quadrant': {
+        'axis motion': {
+            0: {
+                # A throttle axis that uses a button to switch into
+                # reverse mode.
+                'axis type': 'THROTTLE_WITH_REVERSE_BUTTON',
+                'psx variable': 'Tla',
+                'axis swap': False,
+                # We have a detent to limit forward travel
+                'axis min': -1.00,
+                'axis max': 1.00,
+                # Values to send to PSX at idle and full thrust
+                'psx idle': 0,
+                'psx full': 5000,
+                # PSX values to send at reverse idle and reverse full
+                'psx reverse idle': -3000,
+                'psx reverse full': -8925,
+                # Only possible to toggle reverse when axis is in this range
+                'reverse lever unlocked range': (-1.0, -0.90),
+                # The PSX engines (1-2) controlled by this throttle
+                'engine indexes': [0],
+                # The button that triggers reverse
+                'reverse button': 8,
+		        # 'static zones': [(0.62, 1.00, 1.00)],  # axis min, axis max, axis replacement value
+            },
+            5: {
+                'axis type': 'THROTTLE_WITH_REVERSE_BUTTON',
+                'psx variable': 'Tla',
+                'axis swap': False,
+                'axis min': -1.00,
+                'axis max': 1.00,
+                'psx idle': 0,
+                'psx full': 5000,
+                'psx reverse idle': -3000,
+                'psx reverse full': -8925,
+                'reverse lever unlocked range': (-1.0, -0.90),
+                'engine indexes': [1],
+                'reverse button': 9,
+		        # 'static zones': [(0.62, 1.00, 1.00)],  # axis min, axis max, axis replacement value
+            },
+            4: {
+                'axis type': 'THROTTLE_WITH_REVERSE_BUTTON',
+                'psx variable': 'Tla',
+                'axis swap': False,
+                'axis min': -1.00,
+                'axis max': 1.00,
+                'psx idle': 0,
+                'psx full': 5000,
+                'psx reverse idle': -3000,
+                'psx reverse full': -8925,
+                'reverse lever unlocked range': (-1.0, -0.990),
+                'engine indexes': [2],
+                'reverse button': 10,
+		        # 'static zones': [(0.62, 1.00, 1.00)],  # axis min, axis max, axis replacement value
+            },
+            3: {
+                'axis type': 'THROTTLE_WITH_REVERSE_BUTTON',
+                'psx variable': 'Tla',
+                'axis swap': False,
+                'axis min': -1.00,
+                'axis max': 1.00,
+                'psx idle': 0,
+                'psx full': 5000,
+                'psx reverse idle': -3000,
+                'psx reverse full': -8925,
+                'reverse lever unlocked range': (-1.0, -0.90),
+                'engine indexes': [3],
+                'reverse button': 11,
+		        # 'static zones': [(0.62, 1.00, 1.00)],  # axis min, axis max, axis replacement value
+            },
+            1: {
+                # Speedbrake
+                'axis type': 'SPEEDBRAKE',
+                'psx variable': 'SpdBrkLever',
+                'axis swap': True,
+				# When the axis value is less than this, the speedbrake is stowed
+                'limit stowed': 0.025,
+                # Else when the axis value is less than this, the speedbrake is armed
+                'limit armed': 0.17,
+                # Else when the axis value is greater than this, the speedbrake is full (ground)
+                'limit flight upper': 0.9,
+                # Else the speedbrake is in the flight range
+            },
+        },
+        'button down': {
+			0: {
+				# Towing mode toggle
+				'button type': 'TOWING_MODE_TOGGLE',
+				'psx variable': 'Towing',
+			},
+			1: {
+				# Towing direction toggle
+				'button type': 'TOWING_DIRECTION_TOGGLE',
+				'psx variable': 'Towing',
+			},
+            6: {
+                # EcpStdCp
+                'button type': 'SET',
+                'psx variable': 'EcpStdCp',
+                'value': 1,
+            },
+            7: {
+                # McpPshCmdL
+                'button type': 'SET',
+                'psx variable': 'McpPshCmdL',
+                'value': 1,
+            },
+            8: {
+                # Reverser 1
+                'button type': 'REVERSE_LEVER',
+                'axis': 0,
+            },
+            9: {
+                # Reverser 2
+                'button type': 'REVERSE_LEVER',
+                'axis': 5,
+            },
+            10: {
+                # Reverser 3
+                'button type': 'REVERSE_LEVER',
+                'axis': 4,
+            },
+            11: {
+                # Reverser 4
+                'button type': 'REVERSE_LEVER',
+                'axis': 3,
+            },
+			12: {
+				# Towing heading
+				'button type': 'TOWING_HEADING',
+				'increment': +1,
+				'psx variable': 'Towing',
+			},
+			13: {
+				# Towing heading
+				'button type': 'TOWING_HEADING',
+				'increment': -1,
+				'psx variable': 'Towing',
+			},
+            # # Captain ND zoom
+	        # 12: {
+            #     'button type': 'INCREMENT',
+            #     'psx variable': 'EcpBaroCp',
+            #     'increment': 1,
+            #     'min': -6000, 'max': 6000, 'wrap': False,
+            # },
+            # 13: {
+            #     'button type': 'INCREMENT',
+            #     'psx variable': 'EcpBaroCp',
+            #     'increment': -1,
+            #     'min': -6000, 'max': 6000, 'wrap': False,
+            # },
+            14: {
+                # Flap lever down -1
+                'button type': 'INCREMENT',
+                'psx variable': 'FlapLever',
+                'increment': 1,
+                'min': 0, 'max': 6,
+            },
+            15: {
+                # Flaps lever up +1
+                'button type': 'INCREMENT',
+                'psx variable': 'FlapLever',
+                'increment': -1,
+                'min': 0, 'max': 6,
+            },
+            # Autobrake, value: RTO
+            16: {
+                'button type': 'SET',
+                'psx variable': 'Autobr',
+                'value': 0,
+
+            },
+            # Autobrake, value: 1
+            17: {
+                'button type': 'SET',
+                'psx variable': 'Autobr',
+                'value': 1,
+            },
+            # Autobrake, value: 2
+            18: {
+                'button type': 'SET',
+                'psx variable': 'Autobr',
+                'value': 3,
+            },
+            # Autobrake, value: 3
+            19: {
+                'button type': 'SET',
+                'psx variable': 'Autobr',
+                'value': 4,
+            },
+            # Autobrake, value: 4
+            20: {
+                'button type': 'SET',
+                'psx variable': 'Autobr',
+                'value': 5,
+            },
+            41: {
+                # Autothrottle, on
+                'button type': 'SET',
+                'psx variable': 'McpAtArm',
+                'value': 1,
+            },
+            42: {
+                # Autothrottle, off
+                'button type': 'SET',
+                'psx variable': 'McpAtArm',
+                'value': 0,
+            },
+            43: {
+                # Strobes, on
+                'button type': 'SET',
+                'psx variable': 'LtStrobe',
+                'value': 1,
+            },
+            44: {
+                # Strobes, off
+                'button type': 'SET',
+                'psx variable': 'LtStrobe',
+                'value': 0,
+            },
+            # # Landing lights, on
+            # 43: {
+            #     'button type': 'SET',
+            #     'psx variable': 'LtLandOubL',
+            #     'value': 1,
+            #     'psx variable': 'LtLandOubR',
+            #     'value': 1,
+            # },
+            # # Landing lights, off
+            # 44: {
+            #     'button type': 'SET',
+            #     'psx variable': 'LtLandOubL',
+            #     'value': 0,
+            #     'psx variable': 'LtLandOubR',
+            #     'value': 0,
+            # },
+
+            # For now on Yoke
+            # # Gear lever
+            # 30: {
+            #     'button type': 'SET',
+            #     'psx variable': 'GearLever',
+            #     'value': 2,
+            # },
+            # 31: {
+            #     'button type': 'SET',
+            #     'psx variable': 'GearLever',
+            #     'value': 2,
+            # },
+        },
+        'button up': {
+            # Reversers
+            8: {
+                'button type': 'REVERSE_LEVER',
+                'axis': 0,
+            },
+            9: {
+                'button type': 'REVERSE_LEVER',
+                'axis': 5,
+            },
+            10: {
+                'button type': 'REVERSE_LEVER',
+                'axis': 4,
+            },
+            11: {
+                'button type': 'REVERSE_LEVER',
+                'axis': 3,
+            },
+        },
+    },
+    #
+    # TCA YOKE BOEING descriptions
+    #
+    # Left
+    # (1) 2 4
+    #     X Y
+    #     3 5
+    # Back: 0
+    #
+    # Middle
+    # (15)(14)(13)
+    #
+    # Right
+    #      6 A 7
+    # (12) 8 B 9 (10)
+    # Back: 11
+    #
+	'TCA YOKE BOEING': {
+		'axis motion': {
+            0: {
+                # Aileron
+                'axis type': 'NORMAL',
+                'psx variable': 'FltControls',
+                'indexes': [1],
+                'psx min': -999,
+                'psx max': 999,
+                #'static zones': [(-0.01, 0.01, 0.0)],  # axis min, axis max, axis replacement value
+                'static zones': [(-0.05, 0.05, 0.0)], 
+                #'static zones': [(-0.30, -0.14, 0.0)],  # axis min, axis max, axis replacement value
+                'tiller': True,
+            },
+            1: {
+                # Elevator
+                'axis type': 'NORMAL',
+                'psx variable': 'FltControls',
+                'indexes': [0],
+                'psx min': -999,
+                'psx max': 999,
+                'static zones': [(-0.01, 0.01, 0.0)],  # axis min, axis max, axis replacement value
+            },
+        },
+        'button down': {
+            0: {
+                'button type': 'FLIGHT_CONTROL_LOCK_TOGGLE',
+            },
+            1: {
+                'button type': 'TILLER_TOGGLE',
+            },
+			# 2: {
+            #     # Trim nose down
+            #     'button type': 'SET',
+            #     'psx variable': 'StabTrimCp',
+            #     'value': -1,
+            # },
+			# 3: {
+            #     # Trim nose up
+            #     'button type': 'SET',
+            #     'psx variable': 'StabTrimCp',
+            #     'value': 1,
+            # },
+            # Captain ND zoom
+	        6: {
+                'button type': 'INCREMENT',
+                'psx variable': 'EcpNdRangeCp',
+                'increment': -1,
+                'min': 0, 'max': 7, 'wrap': True,
+            },
+            7: {
+                'button type': 'INCREMENT',
+                'psx variable': 'EcpNdRangeCp',
+                'increment': 1,
+                'min': 0, 'max': 7, 'wrap': True,
+            },
+            # 8: {
+            #     # Flaps
+            #     'button type': 'INCREMENT',
+            #     'psx variable': 'FlapLever',
+            #     'increment': 1,
+            #     'min': 0, 'max': 6,
+            # },
+            # 9: {
+            #     # Flaps
+            #     'button type': 'INCREMENT',
+            #     'psx variable': 'FlapLever',
+            #     'increment': -1,
+            #     'min': 0, 'max': 6,
+            # },
+            10: {
+                # AP disconnect
+                'button type': 'SET',
+                'psx variable': 'ApDisc',
+				'value': 1,
+            },
+            14: {
+                # TOGA and A/T off (was: 22)
+                'button type': 'SET',
+                'psx variable': 'ThrustToga',
+                'value': 3,
+
+            },
+            17: {
+                # Gear lever
+                'button type': 'SET',
+                'psx variable': 'GearLever',
+                'value': 1,
+            },
+        },
+        'button up': {
+			# 2: {
+            #     # Trim nose down
+            #     'button type': 'SET',
+            #     'psx variable': 'StabTrimCp',
+            #     'value': 0,
+            # },
+			# 3: {
+            #     # Trim nose up
+            #     'button type': 'SET',
+            #     'psx variable': 'StabTrimCp',
+            #     'value': 0,
+            # },
+            17: {
+                'button type': 'SET',
+                'psx variable': 'GearLever',
+                'value': 3,
+            },
+        },
+    },
+}


### PR DESCRIPTION
Added a config example for the Honeycomb Bravo throttle quadrant. Comments added, should be fairly self-explanatory. Focus was on:
- pushback
- throttle axises + reversers
- flaps
- speedbrake
- autobrake